### PR TITLE
fix: Resolve all Markdown linting errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,56 +5,63 @@ This MCP server provides tools for interacting with a local KinD Kubernetes clus
 ## Prerequisites
 
 - Python 3.8+
-- KinD Kubernetes cluster running locally: https://kind.sigs.k8s.io/docs/user/quick-start/
+- KinD Kubernetes cluster running locally: [https://kind.sigs.k8s.io/docs/user/quick-start/](https://kind.sigs.k8s.io/docs/user/quick-start/)
 - `kubectl` configured to access your cluster
 - pip package manager
 
 ## Creating a Kind Cluster
 
 1. Install KinD if you haven't already:
-```bash
-# On macOS with Homebrew
-brew install kind
 
-# On Linux/Windows with Go
-go install sigs.k8s.io/kind@latest
-```
+   ```bash
+   # On macOS with Homebrew
+   brew install kind
+
+   # On Linux/Windows with Go
+   go install sigs.k8s.io/kind@latest
+   ```
 
 2. Create a new cluster named "test-mcp":
-```bash
-kind create cluster --name test-mcp
-```
+
+   ```bash
+   kind create cluster --name test-mcp
+   ```
 
 3. Verify the cluster is running:
-```bash
-kubectl cluster-info --context kind-test-mcp
-```
+
+   ```bash
+   kubectl cluster-info --context kind-test-mcp
+   ```
 
 4. You should see output similar to:
-```
-Kubernetes control plane is running at https://127.0.0.1:xxxxx
-CoreDNS is running at https://127.0.0.1:xxxxx/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
-```
+
+   ```text
+   Kubernetes control plane is running at https://127.0.0.1:xxxxx
+   CoreDNS is running at https://127.0.0.1:xxxxx/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+   ```
 
 Now your KinD cluster is ready to use with this MCP server.
 
 ## Installation
 
 1. Create a virtual environment and activate it:
-```bash
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-```
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   ```
 
 2. Install the required dependencies:
-```bash
-pip install -r requirements.txt
-```
 
-This will install:
-- `mcp[cli]` - The Model Context Protocol CLI with inspector tools
-- `kubernetes` - The official Kubernetes Python client
-- Additional dependencies for the MCP server
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+   This will install:
+
+   - `mcp[cli]` - The Model Context Protocol CLI with inspector tools
+   - `kubernetes` - The official Kubernetes Python client
+   - Additional dependencies for the MCP server
 
 The MCP Inspector is included with the `mcp[cli]` package and will be available automatically.
 
@@ -67,11 +74,13 @@ There are two ways to use this MCP server:
 The MCP Inspector provides a web interface for testing your tools:
 
 1. Start the server in development mode:
-```bash
-mcp dev kind_server.py
-```
 
-2. Open the URL shown in the console (look for the output text: MCP Inspector is up and running at http://127.0.0.1:6274 🚀)
+   ```bash
+   mcp dev kind_server.py
+   ```
+
+2. Open the URL shown in the console (look for the output text: MCP Inspector is up and running at [http://127.0.0.1:6274](http://127.0.0.1:6274) 🚀)
+
 3. Use the web interface to:
    - View available tools
    - Test tools with different parameters
@@ -81,19 +90,21 @@ mcp dev kind_server.py
 
 To use the MCP server in Cursor:
 
-1. Create an `mcp.json` file in your project (.cursor/mcp.json) or in the global Cursor path (https://docs.cursor.com/context/model-context-protocol):
-```json
-{
-  "mcpServers": {
-    "kind-k8s-mcp": {
-      "command": "/path/to/your/venv/bin/python",
-      "args": ["/path/to/your/kind_server.py"],
-    }
-  }
-}
-```
+1. Create an `mcp.json` file in your project (.cursor/mcp.json) or in the global Cursor path ([https://docs.cursor.com/context/model-context-protocol](https://docs.cursor.com/context/model-context-protocol)):
+
+   ```json
+   {
+     "mcpServers": {
+       "kind-k8s-mcp": {
+         "command": "/path/to/your/venv/bin/python",
+         "args": ["/path/to/your/kind_server.py"],
+       }
+     }
+   }
+   ```
 
 2. Cursor will automatically detect and use the MCP server
+
 3. The tools will be available in your AI interactions
 
 ## Available Tools
@@ -135,18 +146,21 @@ The server provides the following tools:
 ## Error Handling
 
 The server includes robust error handling for common scenarios:
+
 - Invalid namespace names
 - Cluster connectivity issues
 - Authentication/authorization errors
 
 All errors are logged with timestamps and returned as formatted strings with descriptive messages. Example error log:
-```
+
+```text
 2025-XX-XX XX:XX:XX,XXX - ERROR - Error loading kubeconfig: config file not found
 ```
 
 ## Development
 
 When developing or testing new features, use the MCP Inspector (`mcp dev`) for real-time feedback and easy tool testing. The web interface makes it simple to:
+
 - Validate tool inputs
 - Check formatted outputs
 - Debug issues
@@ -155,6 +169,7 @@ When developing or testing new features, use the MCP Inspector (`mcp dev`) for r
 ### Monitoring Server Status
 
 The server provides continuous status updates through logging:
+
 1. **Startup Phase**:
    - Kubernetes configuration loading
    - Cluster connection verification
@@ -169,4 +184,4 @@ The server provides continuous status updates through logging:
    - Detailed error messages
    - Connection issues
    - Authentication problems
-   - Invalid parameter errors 
+   - Invalid parameter errors


### PR DESCRIPTION
- Fix bare URLs by converting to proper markdown links
- Add proper spacing around lists and code blocks
- Fix ordered list numbering consistency
- Add language specification for code blocks
- Remove trailing spaces
- Improve overall markdown formatting consistency